### PR TITLE
Add index to table and tableset classes using autosummary. Closes #390

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .tox
 *.egg-info
 docs/_build
+summary
 dist
 .coverage
 build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+SUMMARYDIR		= api/summary
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -35,6 +36,7 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+	-rm -rf $(SUMMARYDIR)/*
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,29 @@
+{{ fullname }}
+{{ underline }}
+
+{% block attributes %}
+{% if attributes %}
+.. rubric:: Attributes
+
+.. autosummary::
+{% for item in attributes %}
+  {{ fullname }}.{{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block methods %}
+{% if methods %}
+.. rubric:: Methods
+
+.. autosummary::
+{% for item in methods %}
+  {{ fullname }}.{{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}
+
+.. autoclass:: {{ fullname }}
+    :members:
+    :inherited-members:
+    :undoc-members:

--- a/docs/api/table.rst
+++ b/docs/api/table.rst
@@ -3,6 +3,9 @@ agate.table
 ================
 
 .. automodule:: agate.table
-    :members:
-    :inherited-members:
-    :undoc-members:
+    :members: allow_tableset_proxy
+    
+    .. autosummary::
+        :toctree: summary
+
+        agate.table.Table

--- a/docs/api/tableset.rst
+++ b/docs/api/tableset.rst
@@ -3,6 +3,9 @@ agate.tableset
 ===================
 
 .. automodule:: agate.tableset
-    :members:
-    :inherited-members:
-    :undoc-members:
+    :members: TableMethodProxy
+    
+    .. autosummary::
+        :toctree: summary
+
+        agate.tableset.TableSet

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,10 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 # Extensions
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.autosummary']
 autodoc_member_order = 'bysource'
+
+autosummary_generate = True
 
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3.5', None)


### PR DESCRIPTION
Here's how I was trying to add an index to table and tableset. On `make html`, autosummary will generate rst pages for the Table and TableSet classes with indexes. I added a line to `make clean` to delete those generated files. 

It feels off to me but its better than manually typing out the toctree. There was also some trouble on readthedocs and sphinx with autosummary but it seems resolved in the latest release of sphinx: https://github.com/rtfd/readthedocs.org/issues/1290.