### PR TITLE
number_formatter creation in the preview module now passes on the locale of Number objects to be more explict and try to fix the Windows bug in #453

### DIFF
--- a/agate/preview.py
+++ b/agate/preview.py
@@ -89,8 +89,8 @@ def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_c
             elif v is None:
                 v = ''
             elif number_formatters[j] is not None:
-                format, locale = number_formatters[j]
-                v = format_decimal(v, format=format, locale=locale)
+                fmt, lcl = number_formatters[j]
+                v = format_decimal(v, format=fmt, locale=lcl)
             else:
                 v = six.text_type(v)
 

--- a/agate/preview.py
+++ b/agate/preview.py
@@ -67,7 +67,12 @@ def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_c
 
         if isinstance(c.data_type, Number):
             max_places = max_precision(c[:max_rows])
-            number_formatters.append(make_number_formatter(max_places))
+            number_formatters.append(
+                (
+                    make_number_formatter(max_places),
+                    c.data_type.locale
+                )
+            )
         else:
             number_formatters.append(None)
 
@@ -84,7 +89,8 @@ def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_c
             elif v is None:
                 v = ''
             elif number_formatters[j] is not None:
-                v = format_decimal(v, format=number_formatters[j])
+                format, locale = number_formatters[j]
+                v = format_decimal(v, format=format, locale=locale)
             else:
                 v = six.text_type(v)
 

--- a/agate/preview.py
+++ b/agate/preview.py
@@ -10,6 +10,7 @@ except ImportError:  # pragma: no cover
 
 import sys
 
+from babel.core import default_locale
 from babel.numbers import format_decimal
 import six
 from six.moves import zip
@@ -37,8 +38,12 @@ TICK_MARK = u'+'
 #: Characters to render for ellipsis
 ELLIPSIS = u'...'
 
+# Get the default locale for number formatting
+# (Falls back to English to work around a Windows bug)
+LC_NUMERIC = default_locale('LC_NUMERIC') or 'en_US'
 
-def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_column_width=None):
+
+def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_column_width=None, locale=None):
     """
     See :meth:`.Table.print_table` for documentation.
     """
@@ -67,12 +72,7 @@ def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_c
 
         if isinstance(c.data_type, Number):
             max_places = max_precision(c[:max_rows])
-            number_formatters.append(
-                (
-                    make_number_formatter(max_places),
-                    c.data_type.locale
-                )
-            )
+            number_formatters.append(make_number_formatter(max_places))
         else:
             number_formatters.append(None)
 
@@ -89,8 +89,11 @@ def print_table(table, max_rows=None, max_columns=None, output=sys.stdout, max_c
             elif v is None:
                 v = ''
             elif number_formatters[j] is not None:
-                fmt, lcl = number_formatters[j]
-                v = format_decimal(v, format=fmt, locale=lcl)
+                v = format_decimal(
+                    v,
+                    format=number_formatters[j],
+                    locale=locale or LC_NUMERIC
+                )
             else:
                 v = six.text_type(v)
 
@@ -227,7 +230,12 @@ def print_bars(table, label_column_name, value_column_name, domain=None, width=1
     formatted_values = []
 
     for value in value_column:
-        formatted_values.append(format_decimal(value, format=value_formatter))
+        formatted_values.append(format_decimal(
+                value,
+                format=value_formatter,
+                locale=LC_NUMERIC
+            )
+        )
 
     max_label_width = max(max([len(l) for l in formatted_labels]), len(y_label))
     max_value_width = max(max([len(v) for v in formatted_values]), len(x_label))
@@ -313,7 +321,11 @@ def print_bars(table, label_column_name, value_column_name, domain=None, width=1
     ticks_formatted = OrderedDict()
 
     for k, v in ticks.items():
-        ticks_formatted[k] = format_decimal(v, format=tick_formatter)
+        ticks_formatted[k] = format_decimal(
+            v,
+            format=tick_formatter,
+            locale=LC_NUMERIC
+        )
 
     def write(line):
         output.write(line + '\n')

--- a/agate/table.py
+++ b/agate/table.py
@@ -1353,7 +1353,7 @@ class Table(utils.Patchable):
 
         return Table(bins.items(), column_names, column_types, row_names=tuple(bins.keys()))
 
-    def print_table(self, max_rows=None, max_columns=None, output=sys.stdout, max_column_width=20):
+    def print_table(self, max_rows=None, max_columns=None, output=sys.stdout, max_column_width=20, locale=None):
         """
         Print a well-formatted preview of this table to the console or any
         other output.
@@ -1367,8 +1367,11 @@ class Table(utils.Patchable):
         :param max_column_width:
             Truncate all columns to at most this width. The remainder will be
             replaced with ellipsis.
+        :param locale:
+            Provide a locale you would like to be used to format the output.
+            By default it will use the system's setting.
         """
-        print_table(self, max_rows, max_columns, output, max_column_width)
+        print_table(self, max_rows, max_columns, output, max_column_width, locale)
 
     def print_html(self, max_rows=None, max_columns=None, output=sys.stdout):
         """

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1175,7 +1175,7 @@ class TestBins(AgateTestCase):
 class TestPrettyPrint(AgateTestCase):
     def setUp(self):
         self.rows = (
-            ('1.7', 2, 'a'),
+            ('1.7', 2000, 'a'),
             ('11.18', None, None),
             ('0', 1, 'c')
         )
@@ -1199,7 +1199,7 @@ class TestPrettyPrint(AgateTestCase):
         lines = output.getvalue().split('\n')
 
         self.assertEqual(len(lines), 8)
-        self.assertEqual(len(lines[0]), 25)
+        self.assertEqual(len(lines[0]), 27)
 
     def test_print_table_max_rows(self):
         table = Table(self.rows, self.column_names, self.column_types)
@@ -1209,7 +1209,7 @@ class TestPrettyPrint(AgateTestCase):
         lines = output.getvalue().split('\n')
 
         self.assertEqual(len(lines), 8)
-        self.assertEqual(len(lines[0]), 25)
+        self.assertEqual(len(lines[0]), 27)
 
     def test_print_table_max_columns(self):
         table = Table(self.rows, self.column_names, self.column_types)
@@ -1219,7 +1219,7 @@ class TestPrettyPrint(AgateTestCase):
         lines = output.getvalue().split('\n')
 
         self.assertEqual(len(lines), 8)
-        self.assertEqual(len(lines[0]), 23)
+        self.assertEqual(len(lines[0]), 25)
 
     def test_print_table_max_column_width(self):
         rows = (
@@ -1236,6 +1236,18 @@ class TestPrettyPrint(AgateTestCase):
 
         self.assertIn(' this... ', lines[3])
         self.assertIn(' nope ', lines[5])
+
+    def test_print_table_locale(self):
+        """
+        Verify that the locale of the international number is correctly
+        controlling the format of how it is printed.
+        """
+        table = Table(self.rows, self.column_names, self.column_types)
+
+        output = six.StringIO()
+        table.print_table(max_columns=2, output=output)
+        # If it's working, the english '2,000' should appear as '2.000'
+        self.assertTrue("2.000" in output.getvalue())
 
     def test_print_html(self):
         table = Table(self.rows, self.column_names, self.column_types)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1181,10 +1181,15 @@ class TestPrettyPrint(AgateTestCase):
         )
 
         self.number_type = Number()
+        self.international_number_type = Number(locale='de_DE')
         self.text_type = Text()
 
         self.column_names = ['one', 'two', 'three']
-        self.column_types = [self.number_type, self.number_type, self.text_type]
+        self.column_types = [
+            self.number_type,
+            self.international_number_type,
+            self.text_type
+        ]
 
     def test_print_table(self):
         table = Table(self.rows, self.column_names, self.column_types)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1245,7 +1245,7 @@ class TestPrettyPrint(AgateTestCase):
         table = Table(self.rows, self.column_names, self.column_types)
 
         output = six.StringIO()
-        table.print_table(max_columns=2, output=output)
+        table.print_table(max_columns=2, output=output, locale='de_DE')
         # If it's working, the english '2,000' should appear as '2.000'
         self.assertTrue("2.000" in output.getvalue())
 


### PR DESCRIPTION
For #453