### PR TITLE
Drafted a new 'percents' method on Table objects to allow the rapid computation of a new column. For #497.

### DIFF
--- a/agate/table.py
+++ b/agate/table.py
@@ -46,6 +46,7 @@ except ImportError:
 
 from agate.aggregations import Min, Max
 from agate.columns import Column
+from agate.computations import Percent
 from agate.data_types import TypeTester, DataType, Text, Number
 from agate.exceptions import DataTypeError
 from agate.mapped_sequence import MappedSequence
@@ -1313,6 +1314,26 @@ class Table(utils.Patchable):
         column_types = [key_type, Number()]
 
         return Table(output.items(), column_names, column_types, row_names=tuple(output.keys()))
+
+    @allow_tableset_proxy
+    def percents(self, key, key_name=None):
+        """
+        Computers the percentage of occurrences of each distinct value in a
+        column. Creates a new table with the percent column appended.
+
+        This is effectively equivalent to doing a :meth:`.TableSet.compute`
+        with a :class:`.Percent` aggregator.
+
+        :param key:
+            Either the name of a column from the this table to compute, or a
+            :class:`function` that takes a row and returns a value to count.
+        :param key_name:
+            A name that describes the counted properties. Defaults to the
+            column name that was counted or "group" if counting with a key
+            function.
+        """
+        key_name = key_name or 'percent'
+        return self.compute([(key_name, Percent(key))])
 
     @allow_tableset_proxy
     def bins(self, column_name, count=10, start=None, end=None):

--- a/agate/table.py
+++ b/agate/table.py
@@ -1316,7 +1316,7 @@ class Table(utils.Patchable):
         return Table(output.items(), column_names, column_types, row_names=tuple(output.keys()))
 
     @allow_tableset_proxy
-    def percents(self, key, key_name='percent'):
+    def percents(self, key, key_name='percent', total=None):
         """
         Computers the percentage of occurrences of each distinct value in a
         column. Creates a new table with the percent column appended.
@@ -1331,8 +1331,12 @@ class Table(utils.Patchable):
             A name that describes the counted properties. Defaults to the
             column name that was counted or "group" if counting with a key
             function.
+        :param total:
+            An option on the percent computation that allows you to override
+            the denominator each value will be divided against. The default
+            behavior is to use the sum of the column's values.
         """
-        return self.compute([(key_name, Percent(key))])
+        return self.compute([(key_name, Percent(key, total=total))])
 
     @allow_tableset_proxy
     def bins(self, column_name, count=10, start=None, end=None):

--- a/agate/table.py
+++ b/agate/table.py
@@ -1316,7 +1316,7 @@ class Table(utils.Patchable):
         return Table(output.items(), column_names, column_types, row_names=tuple(output.keys()))
 
     @allow_tableset_proxy
-    def percents(self, key, key_name=None):
+    def percents(self, key, key_name='percent'):
         """
         Computers the percentage of occurrences of each distinct value in a
         column. Creates a new table with the percent column appended.
@@ -1332,7 +1332,6 @@ class Table(utils.Patchable):
             column name that was counted or "group" if counting with a key
             function.
         """
-        key_name = key_name or 'percent'
         return self.compute([(key_name, Percent(key))])
 
     @allow_tableset_proxy

--- a/scratch.py
+++ b/scratch.py
@@ -1,0 +1,32 @@
+import agate
+
+
+column_names = ['name', 'race', 'gender']
+column_types = [agate.Text(), agate.Text(), agate.Text()]
+rows = (
+    ('joe', 'white', 'male'),
+    ('jane', 'white', 'female'),
+    ('josh', 'black', 'male'),
+    ('jim', 'latino', 'male'),
+    ('julia', 'white', 'female'),
+    ('joan', 'asian', 'female'),
+)
+people = agate.Table(rows, column_names, column_types)
+
+by_race = people.group_by("race").aggregate([
+    ('total', agate.Length()),
+])
+
+gender_by_race = {}
+for row in by_race.rows:
+    race = row[0]
+    gender_by_race[race] = {
+        'male': len(people.where(lambda r: r['race'] == race and r['gender'] == 'male').rows),
+        'female': len(people.where(lambda r: r['race'] == race and r['gender'] == 'male').rows)
+    }
+
+totals = by_race.compute([
+    ('male', agate.Formula(agate.Number(), lambda r: gender_by_race[r['race']]['male'])),
+    ('female', agate.Formula(agate.Number(), lambda r: gender_by_race[r['race']]['female'])),
+])
+totals.print_table()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1076,6 +1076,66 @@ class TestCounts(AgateTestCase):
         ])
 
 
+class TestPercents(AgateTestCase):
+    def setUp(self):
+        self.rows = (
+            (2, 'N'),
+            (2, 'N'),
+            (1, 'N'),
+            (None, None),
+            (3, 'N')
+        )
+
+        self.number_type = Number()
+        self.text_type = Text()
+
+        self.column_names = ['one', 'two']
+        self.column_types = [self.number_type, self.text_type]
+
+    def test_percents_numbers(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        new_table = table.percents("one")
+
+        self.assertIsNot(new_table, table)
+        self.assertColumnNames(new_table, ['one', 'two', 'percent'])
+        self.assertColumnTypes(new_table, [Number, Text, Number])
+        self.assertRows(new_table, [
+            [2, 'N', 25.0],
+            [2, 'N', 25.0],
+            [1, 'N', 12.5],
+            [None, None, None],
+            [3, 'N', 37.5]
+        ])
+
+    def test_percents_counts_numbers(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        new_table = table.counts('one').percents("count")
+
+        self.assertIsNot(new_table, table)
+        self.assertColumnNames(new_table, ['one', 'count', 'percent'])
+        self.assertColumnTypes(new_table, [Number, Number, Number])
+        self.assertRowNames(new_table, [2, 1, None, 3])
+        self.assertRows(new_table, [
+            [2, 2, 40.0],
+            [1, 1, 20.0],
+            [None, 1, 20.0],
+            [3, 1, 20.0]
+        ])
+
+    def test_counts_counts_text(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        new_table = table.counts('two').percents("count", "pct")
+
+        self.assertIsNot(new_table, table)
+        self.assertColumnNames(new_table, ['two', 'count', 'pct'])
+        self.assertColumnTypes(new_table, [Text, Number, Number])
+        self.assertRowNames(new_table, ['N', None])
+        self.assertRows(new_table, [
+            ['N', 4, 80.0],
+            [None, 1, 20.0]
+        ])
+
+
 class TestBins(AgateTestCase):
     def setUp(self):
         self.number_type = Number()


### PR DESCRIPTION
This is my new bicycle.

```python
table.counts("column").percents("count")
```

But it could just as easily be:

```python
table.percents("column")
```