### PR TITLE
A more informative error message when you try to edit a row's content

### DIFF
--- a/agate/mapped_sequence.py
+++ b/agate/mapped_sequence.py
@@ -69,6 +69,15 @@ class MappedSequence(Sequence):
         else:
             return self.dict()[key]
 
+    def __setitem__(self, key, value):
+        """
+        Set values by index, which we want to fail loudly.
+        """
+        raise TypeError("Rows are read only and do not support item \
+assignment. Rather that overwrite your existing data, you could create a \
+new column based on its contents. Learn how here: \
+http://agate.readthedocs.org/en/latest/tutorial.html#computing-new-columns")
+
     def __iter__(self):
         """
         Iterate over values.


### PR DESCRIPTION
For #499. I think this is the kind of thing that can help newbies out. It would have helped me if I encountered the first time I was fiddling around with the app.

```python
table.rows[0][0] = 'foo'
Traceback (most recent call last):
  File "example.py", line 11, in <module>
    table.rows[0][0] = 'foo'
  File "/home/ben/Code/agate/agate/mapped_sequence.py", line 79, in __setitem__
    http://agate.readthedocs.org/en/latest/tutorial.html#computing-new-columns")
TypeError: Rows are read only and do not support item assignment. Rather that overwrite your existing data, you could create a new column based on its contents. Learn how here: http://agate.readthedocs.org/en/latest/tutorial.html#computing-new-columns
```