### PR TITLE
Add Binary data_type

### DIFF
--- a/agate/data_types/__init__.py
+++ b/agate/data_types/__init__.py
@@ -18,6 +18,7 @@ from agate.data_types.date_time import DateTime
 from agate.data_types.number import Number
 from agate.data_types.text import Text
 from agate.data_types.time_delta import TimeDelta
+from agate.data_types.binary import Binary
 from agate.exceptions import CastError  # noqa
 
 
@@ -50,6 +51,7 @@ class TypeTester(object):
         else:
             # In order of preference
             self._possible_types = [
+                Binary(),
                 Boolean(),
                 Number(),
                 TimeDelta(),

--- a/agate/data_types/binary.py
+++ b/agate/data_types/binary.py
@@ -32,14 +32,14 @@ class Binary(DataType):
         if d is None:
             return d
         elif type(d) is int or isinstance(d, Decimal):
-            if d is 0 or d is 1:
+            if d == 0 or d == 1:
                 return d
         elif isinstance(d, six.string_types):
             d = d.replace(',', '').strip()
             
             if d in self.null_values:
                 return None
-            elif d is '0' or d is '1':
+            elif d == '0' or d == '1':
                 return int(d)
 
         raise CastError('Can not convert value %s to binary.' % d)

--- a/agate/data_types/binary.py
+++ b/agate/data_types/binary.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+try:
+    from cdecimal import Decimal
+except ImportError:  # pragma: no cover
+    from decimal import Decimal
+
 import six
 
 from agate.data_types.base import DataType, DEFAULT_NULL_VALUES
@@ -26,7 +31,7 @@ class Binary(DataType):
 
         if d is None:
             return d
-        elif type(d) is int:
+        elif type(d) is int or isinstance(d, Decimal):
             if d is 0 or d is 1:
                 return d
         elif isinstance(d, six.string_types):

--- a/agate/data_types/binary.py
+++ b/agate/data_types/binary.py
@@ -13,8 +13,8 @@ class Binary(DataType):
     other numbers are.
 
     """
-    def __init__(self):
-        super(Binary, self).__init__()
+    def __init__(self, null_values=DEFAULT_NULL_VALUES):
+        super(Binary, self).__init__(null_values=null_values)
 
     def cast(self, d):
         """

--- a/agate/data_types/binary.py
+++ b/agate/data_types/binary.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import six
+
+from agate.data_types.base import DataType, DEFAULT_NULL_VALUES
+from agate.exceptions import CastError
+
+class Binary(DataType):
+    """
+    Data type representing Binary values.
+
+    Note: numerical `1` and `0` are considered valid binary values, but no
+    other numbers are.
+
+    """
+    def __init__(self):
+        super(Binary, self).__init__()
+
+    def cast(self, d):
+        """
+        Cast a single value to :class:`bool`.
+
+        :param d: A value to cast.
+        :returns: :class:`bool` or :code:`None`.
+        """
+
+        if d is None:
+            return d
+        elif type(d) is int:
+            if d is 0 or d is 1:
+                return d
+        elif isinstance(d, six.string_types):
+            d = d.replace(',', '').strip()
+            
+            if d in self.null_values:
+                return None
+            elif d is '0' or d is '1':
+                return int(d)
+
+        raise CastError('Can not convert value %s to binary.' % d)
+
+    def jsonify(self, d):
+        return d

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -348,6 +348,28 @@ class TestTimeDelta(unittest.TestCase):
             self.type.cast('quack')
 
 
+class TestBinary(unittest.TestCase):
+    def setUp(self):
+        self.type = Binary()
+
+    def test_test(self):
+        self.assertEqual(self.type.test(1), True)
+        self.assertEqual(self.type.test(0), True)
+        self.assertEqual(self.type.test('1'), True)
+        self.assertEqual(self.type.test('0'), True)
+        self.assertEqual(self.type.test(5), False)
+        self.assertEqual(self.type.test('a'), False)
+
+    def test_cast_parser(self):
+        values = (1, 0, '1', '0')
+        casted = tuple(self.type.cast(v) for v in values)
+        self.assertSequenceEqual(casted, (1, 0, 1, 0))
+
+    def test_cast_error(self):
+        with self.assertRaises(CastError):
+            self.type.cast('quack')
+
+
 class TestTypeTester(unittest.TestCase):
     def setUp(self):
         self.tester = TypeTester()
@@ -417,6 +439,18 @@ class TestTypeTester(unittest.TestCase):
         inferred = self.tester.run(rows, ['one'])
 
         self.assertIsInstance(inferred[0], Boolean)
+
+    def test_binary_type(self):
+        rows = [
+            (1,),
+            (0,),
+            ('1',),
+            ('0',)
+        ]
+
+        inferred = self.tester.run(rows, ['one'])
+
+        self.assertIsInstance(inferred[0], Binary)
 
     def test_date_type(self):
         rows = [


### PR DESCRIPTION
In cases where you would rather have a simpler binary data type over the more opinionated boolean datatype. Unlike the boolean data type the binary datatype will not alter the input data to a Python boolean. This relates to #545 and #546.