### PR TITLE
Table param column_types now accepts and ordered dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 build
 .proof
 .ipynb_checkpoints
+.idea

--- a/agate/table/__init__.py
+++ b/agate/table/__init__.py
@@ -132,12 +132,10 @@ class Table(utils.Patchable):
         if column_types is None:
             column_types = TypeTester()
 
-        elif isinstance(column_types, OrderedDict):
+        elif isinstance(column_types, dict):
             for v in six.itervalues(column_types):
                 if not isinstance(v, DataType):
                     raise ValueError('Column types must be instances of DataType.')
-
-            self._column_names = tuple(six.iterkeys(column_types))
             column_types = TypeTester(force=column_types)
 
         elif not isinstance(column_types, TypeTester):

--- a/agate/table/__init__.py
+++ b/agate/table/__init__.py
@@ -76,7 +76,8 @@ class Table(utils.Patchable):
     :param column_types:
         A sequence of instances of :class:`.DataType` or an instance of
         :class:`.TypeTester` or `None` in which case a generic TypeTester will
-        be used.
+        be used. Alternatively, an `OrderedDict` with column names as keys and
+        instances of :class:`.DataType` as values.
     :param row_names:
         Specifies unique names for each row. This parameter is
         optional. If specified it may be 1) the name of a single column that

--- a/agate/table/__init__.py
+++ b/agate/table/__init__.py
@@ -130,6 +130,15 @@ class Table(utils.Patchable):
         # Validate column_types
         if column_types is None:
             column_types = TypeTester()
+
+        elif isinstance(column_types, OrderedDict):
+            for v in six.itervalues(column_types):
+                if not isinstance(v, DataType):
+                    raise ValueError('Column types must be instances of DataType.')
+
+            self._column_names = tuple(six.iterkeys(column_types))
+            column_types = TypeTester(force=column_types)
+
         elif not isinstance(column_types, TypeTester):
             for column_type in column_types:
                 if not isinstance(column_type, DataType):

--- a/tests/test_table/__init__.py
+++ b/tests/test_table/__init__.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 import six
+from collections import OrderedDict
 
 from agate import Table
 from agate.data_types import *
@@ -71,6 +72,15 @@ class TestBasic(AgateTestCase):
             (2, '3', 'b'),
             (None, '2', u'👍')
         ])
+
+    def test_create_table_column_types_ordered_dict(self):
+        colTypes = zip(self.column_names, self.column_types)
+        table = Table(self.rows, column_types=OrderedDict(colTypes))
+
+        self.assertColumnNames(table, ['one','two','three'])
+        self.assertColumnTypes(table, [Number, Number, Text])
+        self.assertRows(table, self.rows)
+
 
     def test_create_table_column_names(self):
         table = Table(self.rows, self.column_names)

--- a/tests/test_table/__init__.py
+++ b/tests/test_table/__init__.py
@@ -73,14 +73,21 @@ class TestBasic(AgateTestCase):
             (None, '2', u'👍')
         ])
 
-    def test_create_table_column_types_ordered_dict(self):
-        colTypes = zip(self.column_names, self.column_types)
-        table = Table(self.rows, column_types=OrderedDict(colTypes))
+    def test_create_table_column_types_dict(self):
+        colTypes = dict(zip(self.column_names, self.column_types))
+        table = Table(self.rows, column_names=self.column_names, column_types=colTypes)
 
         self.assertColumnNames(table, ['one','two','three'])
         self.assertColumnTypes(table, [Number, Number, Text])
         self.assertRows(table, self.rows)
 
+    def test_create_table_partial_column_types_dict(self):
+        colTypes = dict(zip(self.column_names[:2], self.column_types[:2]))
+        table = Table(self.rows, column_names=self.column_names, column_types=colTypes)
+
+        self.assertColumnNames(table, ['one', 'two', 'three'])
+        self.assertColumnTypes(table, [Number, Number, Text])
+        self.assertRows(table, self.rows)
 
     def test_create_table_column_names(self):
         table = Table(self.rows, self.column_names)


### PR DESCRIPTION
I got all tests passing in Python3.5 but tox errors out for me so I wasn't able to test in other versions of python.