### PR TITLE
Use babel for data_types.number.CURRENCY_SYMBOLS. Closes #224

### DIFF
--- a/agate/data_types/number.py
+++ b/agate/data_types/number.py
@@ -6,6 +6,7 @@ try:
 except ImportError:  # pragma: no cover
     from decimal import Decimal
 
+from babel import localedata
 from babel.core import Locale
 from babel.numbers import parse_decimal
 import six
@@ -14,8 +15,8 @@ from agate.data_types.base import DataType
 from agate.exceptions import CastError
 
 #: A list of currency symbols sourced from `Xe <http://www.xe.com/symbols.php>`_.
-CURRENCY_SYMBOLS = [u'؋', u'$', u'ƒ', u'៛', u'¥', u'₡', u'₱', u'£', u'€', u'¢', u'﷼', u'₪', u'₩', u'₭', u'₮', u'₦', u'฿', u'₤', u'₫']
-
+CURRENCY_SYMBOLS = list(localedata.load('root')['currency_symbols'].values())
+CURRENCY_SYMBOLS.append(u'¢')
 
 class Number(DataType):
     """
@@ -58,7 +59,10 @@ class Number(DataType):
                 sign = Decimal(-1)
 
             for symbol in CURRENCY_SYMBOLS:
-                d = d.strip(symbol)
+                if d[:len(symbol)] == symbol:
+                    d = d[len(symbol):]
+                if d[(len(d) - len(symbol)):] == symbol:
+                    d = d[:(len(d) - len(symbol))]
 
             if d.lower() in self.null_values:
                 return None

--- a/agate/data_types/number.py
+++ b/agate/data_types/number.py
@@ -14,7 +14,6 @@ import six
 from agate.data_types.base import DataType
 from agate.exceptions import CastError
 
-#: A list of currency symbols sourced from `Xe <http://www.xe.com/symbols.php>`_.
 CURRENCY_SYMBOLS = list(localedata.load('root')['currency_symbols'].values())
 CURRENCY_SYMBOLS.append(u'¢')
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -140,6 +140,15 @@ class TestNumber(unittest.TestCase):
         casted = tuple(self.type.cast(v) for v in values)
         self.assertSequenceEqual(casted, (Decimal('2.7'), Decimal('-0.7'), Decimal('14'), Decimal('50'), Decimal('-75'), Decimal('-1287')))
 
+    def test_currencies(self):
+        #: A list of currency symbols sourced from `Xe <http://www.xe.com/symbols.php>`_.
+        CURRENCY_SYMBOLS = [u'؋', u'$', u'ƒ', u'៛', u'¥', u'₡', u'₱', u'£', u'€', 
+        u'¢', u'﷼', u'₪', u'₩', u'₭', u'₮', u'₦', u'฿', u'₤', u'₫']
+
+        values = [symbol + '1' for symbol in CURRENCY_SYMBOLS]
+        casted = tuple(self.type.cast(v) for v in values)
+        self.assertSequenceEqual(casted, [Decimal(1)] * len(CURRENCY_SYMBOLS))
+
     def test_cast_locale(self):
         values = (2, 1, None, Decimal('2.7'), 'n/a', '2,7', '200.000.000')
         casted = tuple(Number(locale='de_DE').cast(v) for v in values)


### PR DESCRIPTION
@onyxfish Here's a possible fix for #224. babel doesn't have the ¢ symbol so I needed to add that (not sure what else might be missing) and had to change stripping symbols since some have multiple characters. Passing this by you since `Number.cast` is so slow.