### PR TITLE
Remove unneeded space in "agate.table.pivot.pivot()" docstring

### DIFF
--- a/agate/table/pivot.py
+++ b/agate/table/pivot.py
@@ -18,7 +18,7 @@ def pivot(self, key=None, pivot=None, aggregation=None, computation=None, defaul
 
     For example:
 
-    +---------+---------+-- ------+
+    +---------+---------+--------+
     |  name   |  race   | gender |
     +=========+=========+========+
     |  Joe    |  white  | male   |


### PR DESCRIPTION
The space means Sphinx doesn't recognise the reStructuredText markup as a table, and so it's [outputting plain text in the docs] [1] instead of an HTML table.

[1]: http://agate.readthedocs.org/en/1.3.1/api/table.html#agate.Table.pivot