### PR TITLE
Print bar chart when value column contains nulls

### DIFF
--- a/agate/table/print_bars.py
+++ b/agate/table/print_bars.py
@@ -63,18 +63,15 @@ def print_bars(self, label_column_name='group', value_column_name='Count', domai
     value_formatter = utils.make_number_formatter(decimal_places)
 
     formatted_labels = []
-
-    for label in label_column:
-        formatted_labels.append(six.text_type(label))
-
     formatted_values = []
-
-    for value in value_column:
-        formatted_values.append(format_decimal(
-            value,
-            format=value_formatter,
-            locale=utils.LC_NUMERIC
-        ))
+    for index, value in enumerate(value_column):
+        if value is not None:
+            formatted_labels.append(six.text_type(label_column[index]))
+            formatted_values.append(format_decimal(
+                value,
+                format=value_formatter,
+                locale=utils.LC_NUMERIC
+            ))
 
     max_label_width = max(max([len(l) for l in formatted_labels]), len(y_label))
     max_value_width = max(max([len(v) for v in formatted_values]), len(x_label))
@@ -181,8 +178,9 @@ def print_bars(self, label_column_name='group', value_column_name='Count', domai
         zero_mark = utils.ZERO_MARK
 
     # Bars
+    values_without_nulls = value_column.values_without_nulls()
     for i, label in enumerate(formatted_labels):
-        value = value_column[i]
+        value = values_without_nulls[i]
 
         if value == 0:
             bar_width = 0

--- a/agate/table/print_bars.py
+++ b/agate/table/print_bars.py
@@ -63,10 +63,15 @@ def print_bars(self, label_column_name='group', value_column_name='Count', domai
     value_formatter = utils.make_number_formatter(decimal_places)
 
     formatted_labels = []
+
+    for label in label_column:
+        formatted_labels.append(six.text_type(label))
+
     formatted_values = []
-    for index, value in enumerate(value_column):
-        if value is not None:
-            formatted_labels.append(six.text_type(label_column[index]))
+    for value in value_column:
+        if value is None:
+            formatted_values.append("-")
+        else:
             formatted_values.append(format_decimal(
                 value,
                 format=value_formatter,
@@ -178,11 +183,9 @@ def print_bars(self, label_column_name='group', value_column_name='Count', domai
         zero_mark = utils.ZERO_MARK
 
     # Bars
-    values_without_nulls = value_column.values_without_nulls()
     for i, label in enumerate(formatted_labels):
-        value = values_without_nulls[i]
-
-        if value == 0:
+        value = value_column[i]
+        if value == 0 or value is None:
             bar_width = 0
         elif value > 0:
             bar_width = project(value) - plot_negative_width
@@ -194,7 +197,7 @@ def print_bars(self, label_column_name='group', value_column_name='Count', domai
 
         bar = bar_mark * bar_width
 
-        if value >= 0:
+        if value is not None and value >= 0:
             gap = (u' ' * plot_negative_width)
 
             # All positive
@@ -206,7 +209,7 @@ def print_bars(self, label_column_name='group', value_column_name='Count', domai
             bar = u' ' * (plot_negative_width - bar_width) + bar
 
             # All negative or mixed signs
-            if x_max > value:
+            if value is None or x_max > value:
                 bar = bar + zero_mark
 
         bar = bar.ljust(plot_width)

--- a/tests/test_table/test_print_bars.py
+++ b/tests/test_table/test_print_bars.py
@@ -89,3 +89,15 @@ class TestPrintBars(AgateTestCase):
 
         with self.assertRaises(DataTypeError):
             table.print_bars('one', 'three')
+
+    def test_print_bars_with_nulls(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+
+        output = six.StringIO()
+        table.print_bars('three', 'two', width=20, output=output)
+
+        self.assertEqual(output.getvalue(), "three   two\n"
+                                            "a     2,000 ▓░░░░░░░\n"
+                                            "c         1 ▓       \n"
+                                            "            +------+\n"
+                                            "            0  2,000\n")

--- a/tests/test_table/test_print_bars.py
+++ b/tests/test_table/test_print_bars.py
@@ -94,10 +94,11 @@ class TestPrintBars(AgateTestCase):
         table = Table(self.rows, self.column_names, self.column_types)
 
         output = six.StringIO()
-        table.print_bars('three', 'two', width=20, output=output)
+        table.print_bars('three', 'two', width=20, printable=True,
+                         output=output)
 
         self.assertEqual(output.getvalue(), "three   two\n"
-                                            "a     2,000 ▓░░░░░░░\n"
-                                            "c         1 ▓       \n"
+                                            "a     2,000 |:::::::\n"
+                                            "c         1 |       \n"
                                             "            +------+\n"
                                             "            0  2,000\n")

--- a/tests/test_table/test_print_bars.py
+++ b/tests/test_table/test_print_bars.py
@@ -99,6 +99,7 @@ class TestPrintBars(AgateTestCase):
 
         self.assertEqual(output.getvalue(), "three   two\n"
                                             "a     2,000 |:::::::\n"
+                                            "None      - |       \n"
                                             "c         1 |       \n"
                                             "            +------+\n"
                                             "            0  2,000\n")


### PR DESCRIPTION
If the value column contained null values then `agate.Table.print_bars()` would fail with `decimal.InvalidOperation` when trying to convert `None` to a decimal. Now it skips rows with null values in the value column.

If you have a table like this:

Label | Value
------------ | -------------
One | 1
A null value | 
Three | 3

And you run `table.print_bars('label', 'value')`, where previously you would see an error now you see a bar chart with two bars, one for *One*, and one for *Three*.