### PR TITLE
set max_rows=None as the default on Table.print_structure()

### DIFF
--- a/agate/table/print_structure.py
+++ b/agate/table/print_structure.py
@@ -6,7 +6,7 @@ import sys
 from agate.data_types import Text
 
 
-def print_structure(self, output=sys.stdout):
+def print_structure(self, output=sys.stdout, max_rows=None):
     """
     Print this table's column names and types as a plain-text table.
 
@@ -24,4 +24,4 @@ def print_structure(self, output=sys.stdout):
 
     table = Table(rows, column_names, column_types)
 
-    return table.print_table(output=output, max_column_width=None)
+    return table.print_table(output=output, max_column_width=None, max_rows=None)

--- a/agate/table/print_structure.py
+++ b/agate/table/print_structure.py
@@ -24,4 +24,4 @@ def print_structure(self, output=sys.stdout, max_rows=None):
 
     table = Table(rows, column_names, column_types)
 
-    return table.print_table(output=output, max_column_width=None, max_rows=None)
+    return table.print_table(output=output, max_column_width=None, max_rows=max_rows)


### PR DESCRIPTION
Currently the ``Table`` object's ``print_structure`` method does not accept a ``max_rows`` input.

The result is that, whether you want it or not, you are stuck with a 20 row maximum because that is the default of the underlying ``print_table`` method.

I propose that this default be set to ``None``. When I explicitly type ``mytable.print_structure()`` I expect to see the entire structure, regardless of the number of fields. 