### PR TITLE
Add a to_dict method to Table

### DIFF
--- a/agate/table/__init__.py
+++ b/agate/table/__init__.py
@@ -347,6 +347,7 @@ from agate.table.rename import rename
 from agate.table.scatterplot import scatterplot
 from agate.table.select import select
 from agate.table.to_csv import to_csv
+from agate.table.to_dict import to_dict
 from agate.table.to_json import to_json
 from agate.table.where import where
 
@@ -380,5 +381,6 @@ Table.rename = rename
 Table.scatterplot = scatterplot
 Table.select = select
 Table.to_csv = to_csv
+Table.to_dict = to_dict
 Table.to_json = to_json
 Table.where = where

--- a/agate/table/to_dict.py
+++ b/agate/table/to_dict.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# pylint: disable=W0212
+
+from collections import OrderedDict
+
+import six
+
+
+def to_dict(self, key, column_funcs=None):
+    """
+    Convert this table to an OrderedDict.
+
+    :param key:
+        May be either the name of a column from the this table containing
+        unique values or a :class:`function` that takes a row and returns
+        a unique value.
+    :param column_funcs:
+        If specified, a list of functions to apply to the columns in this
+        table. See :meth:`.Table.to_json` for an example.
+    """
+    key_is_row_function = hasattr(key, '__call__')
+
+    output = OrderedDict()
+
+    for row in self._rows:
+        if key_is_row_function:
+            k = key(row)
+        else:
+            k = row[key]
+
+        if k in output:
+            raise ValueError('Value %s is not unique in the key column.' % six.text_type(k))
+
+        if column_funcs:
+            values = tuple(column_funcs[i](d) for i, d in enumerate(row))
+        else:
+            values = tuple(row)
+
+        output[k] = OrderedDict(zip(row.keys(), values))
+
+    return output
+

--- a/agate/table/to_json.py
+++ b/agate/table/to_json.py
@@ -34,8 +34,6 @@ def to_json(self, path, key=None, newline=False, indent=None, **kwargs):
     if newline and indent is not None:
         raise ValueError('newline and indent may not be specified together.')
 
-    key_is_row_function = hasattr(key, '__call__')
-
     json_kwargs = {
         'ensure_ascii': False,
         'indent': indent
@@ -72,19 +70,7 @@ def to_json(self, path, key=None, newline=False, indent=None, **kwargs):
 
         # Keyed
         if key is not None:
-            output = OrderedDict()
-
-            for row in self._rows:
-                if key_is_row_function:
-                    k = key(row)
-                else:
-                    k = row[key]
-
-                if k in output:
-                    raise ValueError('Value %s is not unique in the key column.' % six.text_type(k))
-
-                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
-                output[k] = OrderedDict(zip(row.keys(), values))
+            output = self.to_dict(key, column_funcs=json_funcs)
             dump_json(output)
         # Newline-delimited
         elif newline:

--- a/docs/api/table.rst
+++ b/docs/api/table.rst
@@ -40,6 +40,7 @@ Saving
     :nosignatures:
 
     agate.Table.to_csv
+    agate.Table.to_dict
     agate.Table.to_json
 
 Basic processing

--- a/tests/test_table/test_to_dict.py
+++ b/tests/test_table/test_to_dict.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+import json
+
+from collections import OrderedDict
+
+from agate import Table
+from agate.testcase import AgateTestCase
+from agate.data_types import *
+
+
+class TestDict(AgateTestCase):
+    def setUp(self):
+        self.rows = (
+            (1, 'a', True, '11/4/2015', '11/4/2015 12:22 PM', '4:15'),
+            (2, u'👍', False, '11/5/2015', '11/4/2015 12:45 PM', '6:18'),
+            (None, 'b', None, None, None, None)
+        )
+
+        self.column_names = [
+            'number', 'text', 'boolean', 'date', 'datetime', 'timedelta'
+        ]
+
+        self.column_types = [
+            Number(), Text(), Boolean(), Date(), DateTime(), TimeDelta()
+        ]
+
+        self.json_funcs = [c.jsonify for c in self.column_types]
+
+    def test_to_dict(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+
+        d1 = table.to_dict('text', column_funcs=self.json_funcs)
+
+        with open('examples/test_keyed.json') as f:
+            d2 = json.load(f, object_pairs_hook=OrderedDict)
+
+        self.assertEqual(d1, d2)
+
+    def test_to_dict_func(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+
+        key_func = lambda r: r['text']
+        d1 = table.to_dict(key_func, column_funcs=self.json_funcs)
+
+        with open('examples/test_keyed.json') as f:
+            d2 = json.load(f, object_pairs_hook=OrderedDict)
+
+        self.assertEqual(d1, d2)
+


### PR DESCRIPTION
I have found it useful to be able to convert a Table to an OrderedDict. These changes extract this functionality from Table.to_json() into a new Table.to_dict() method.

Changes:

1. Added to_dict method to Table
2. Added /tests/test_table/test_to_dict.py
3. Modified Table.to_json() to use to_dict()
4. Added to_dict() to the API documentation

I hope you will consider adding this :)

Cheers,
Todd