### PR TITLE
Customize file extensions for globbing csv and json TableSets

### DIFF
--- a/agate/tableset/from_csv.py
+++ b/agate/tableset/from_csv.py
@@ -8,7 +8,7 @@ from agate.table import Table
 
 
 @classmethod
-def from_csv(cls, dir_path, column_names=None, column_types=None, row_names=None, header=True, **kwargs):
+def from_csv(cls, dir_path, column_names=None, column_types=None, row_names=None, header=True, suffix='.csv', **kwargs):
     """
     Create a new :class:`TableSet` from a directory of CSVs.
 
@@ -33,8 +33,8 @@ def from_csv(cls, dir_path, column_names=None, column_types=None, row_names=None
 
     tables = OrderedDict()
 
-    for path in glob(os.path.join(dir_path, '*.csv')):
-        name = os.path.split(path)[1].strip('.csv')
+    for path in glob(os.path.join(dir_path, '*%s' % suffix)):
+        name = os.path.basename(path).strip(suffix)
 
         tables[name] = Table.from_csv(path, column_names, column_types, row_names=row_names, header=header, **kwargs)
 

--- a/agate/tableset/from_json.py
+++ b/agate/tableset/from_json.py
@@ -12,7 +12,7 @@ from agate.table import Table
 
 
 @classmethod
-def from_json(cls, path, column_names=None, column_types=None, keys=None, **kwargs):
+def from_json(cls, path, column_names=None, column_types=None, keys=None, suffix='.json', **kwargs):
     """
     Create a new :class:`TableSet` from a directory of JSON files or a
     single JSON object with key value (Table key and list of row objects)
@@ -37,13 +37,13 @@ def from_json(cls, path, column_names=None, column_types=None, keys=None, **kwar
     tables = OrderedDict()
 
     if isinstance(path, six.string_types) and os.path.isdir(path):
-        filepaths = glob(os.path.join(path, '*.json'))
+        filepaths = glob(os.path.join(path, '*%s'% suffix))
 
         if keys is not None and len(keys) != len(filepaths):
             raise ValueError('If specified, keys must have length equal to number of JSON files')
 
         for i, filepath in enumerate(filepaths):
-            name = os.path.split(filepath)[1].strip('.json')
+            name = os.path.basename(filepath).strip(suffix)
 
             if keys is not None:
                 tables[name] = Table.from_json(filepath, keys[i], column_types=column_types, **kwargs)


### PR DESCRIPTION
I have directories of csv files with different suffixes (a common example would be .tsv , but there are others as well). This allows the user to specify a suffix).

I have some personal use cases where the suffix would be '_foo.txt' and I would like the whole '_foo.txt' striped off, which explains why I have the default arg of '.csv' rather than 'csv' without the period.