### PR TITLE
Docs edit: Add required comma after tuple in aggregate examples

### DIFF
--- a/docs/cookbook/sql.rst
+++ b/docs/cookbook/sql.rst
@@ -197,7 +197,7 @@ agate:
 
     doctors = patients.group_by('doctor')
     patient_ages = doctors.aggregate([
-        ('patient_count', agate.Count())
+        ('patient_count', agate.Count()),
         ('age_mean', agate.Mean('age')),
         ('age_median', agate.Median('age'))
     ])

--- a/docs/cookbook/statistics.rst
+++ b/docs/cookbook/statistics.rst
@@ -40,7 +40,7 @@ You can also generate aggregate statistics for subsets of data (sometimes referr
 
     doctors = patients.group_by('doctor')
     patient_ages = doctors.aggregate([
-        ('patient_count', agate.Count())
+        ('patient_count', agate.Count()),
         ('age_mean', agate.Mean('age')),
         ('age_median', agate.Median('age'))
     ])


### PR DESCRIPTION
Minor fix for missing comma in docs. First two tuples in list input to the aggregate() function weren't separated by a comma.