### PR TITLE
Improve the content of the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGELOG.rst COPYING
+recursive-include docs *
+recursive-include tests *


### PR DESCRIPTION
For a quick context on this, I intend to package `agate` for Debian now that it is a required dependency for `csvkit`. Debian, and other Linux distributions, source themselves from PyPI and build different binary packages from it, providing modules for Python 2, Python 3 and the documentation typically.

Right now, the source tarball hosted on PyPI provides the bare minimum to build the Python binary packages, but provides neither the source for the documentation, nor the test suite necessary to ensure appropriate testing on the packaging side. This PR enhances the content of the release tarball with what Debian considers being good practice for source distribution, i.e.:
- a detailed change log
- the exact license terms
- the documentation
- the test suite

Thanks for considering this proposal.