### PR TITLE
Update csv.rst

### DIFF
--- a/docs/api/csv.rst
+++ b/docs/api/csv.rst
@@ -8,7 +8,7 @@ Agate methods will use these version automatically. If you would like to use the
 
 .. code-block:: python
 
-    import agate as csv
+    from agate import csv
 
 Due to nuanced differences between the versions, these classes are implemented seperately for Python 2 and Python 3. The documentation for both versions is provided below, but only the one for your version of Python is imported with the above code.
 


### PR DESCRIPTION
The current example causes an error.

```python
>>> import agate as csv
>>> csv.DictReader
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'DictReader'
```

So I propose the attached change