### PR TITLE
Fix divide by zero when calculating Means

### DIFF
--- a/agate/aggregations/mean.py
+++ b/agate/aggregations/mean.py
@@ -35,7 +35,10 @@ class Mean(Aggregation):
 
     def run(self, table):
         column = table.columns[self._column_name]
+        num_of_values = len(column.values_without_nulls())
+        # If there are no non-null columns then return null.
+        if num_of_values == 0:
+            return None
 
         sum_total = self._sum.run(table)
-
-        return sum_total / (len(column.values_without_nulls()) or 1)
+        return sum_total / num_of_values

--- a/agate/aggregations/mean.py
+++ b/agate/aggregations/mean.py
@@ -38,4 +38,4 @@ class Mean(Aggregation):
 
         sum_total = self._sum.run(table)
 
-        return sum_total / len(column.values_without_nulls())
+        return sum_total / (len(column.values_without_nulls()) or 1)

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -274,12 +274,14 @@ class TestNumberAggregation(unittest.TestCase):
 
     def test_mean_all_nulls(self):
         """
-        Small test to confirm that if mean calculation is ran on a column of
-        nulls then zero will be returned.
+        Test to confirm mean of only nulls doesn't cause a critical error.
 
+        The assumption here is that if you attempt to perform a mean
+        calculation, on a column which contains only null values, then a null
+        value should be returned to the caller.
         :return:
         """
-        self.assertEqual(Mean('four').run(self.table), Decimal('0'))
+        self.assertIsNone(Mean('four').run(self.table))
 
     def test_mean_with_nulls(self):
         warnings.simplefilter('ignore')

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -211,17 +211,17 @@ class TestDateTimeAggregation(unittest.TestCase):
 class TestNumberAggregation(unittest.TestCase):
     def setUp(self):
         self.rows = (
-            (Decimal('1.1'), Decimal('2.19'), 'a'),
-            (Decimal('2.7'), Decimal('3.42'), 'b'),
-            (None, Decimal('4.1'), 'c'),
-            (Decimal('2.7'), Decimal('3.42'), 'c')
+            (Decimal('1.1'), Decimal('2.19'), 'a', None),
+            (Decimal('2.7'), Decimal('3.42'), 'b', None),
+            (None, Decimal('4.1'), 'c', None),
+            (Decimal('2.7'), Decimal('3.42'), 'c', None)
         )
 
         self.number_type = Number()
         self.text_type = Text()
 
-        self.column_names = ['one', 'two', 'three']
-        self.column_types = [self.number_type, self.number_type, self.text_type]
+        self.column_names = ['one', 'two', 'three', 'four']
+        self.column_types = [self.number_type, self.number_type, self.text_type, self.number_type]
 
         self.table = Table(self.rows, self.column_names, self.column_types)
 
@@ -271,6 +271,15 @@ class TestNumberAggregation(unittest.TestCase):
             Mean('three').validate(self.table)
 
         self.assertEqual(Mean('two').run(self.table), Decimal('3.2825'))
+
+    def test_mean_all_nulls(self):
+        """
+        Small test to confirm that if mean calculation is ran on a column of
+        nulls then zero will be returned.
+
+        :return:
+        """
+        self.assertEqual(Mean('four').run(self.table), Decimal('0'))
 
     def test_mean_with_nulls(self):
         warnings.simplefilter('ignore')


### PR DESCRIPTION
When processing data, sometimes you end up with a column of null values.  If this is then pushed into a pipeline of operations which include calculating the mean on that column, then the whole process errors out.  

I've opted to return None in these situations.  Originally, I planned to return '0' feeling it would be more in keeping with the expected data type from the mean operation.  However, upon reflection, I think this would be a mistake as if the column normally contains '0' and '1' then it might be confusing and misleading.
