### PR TITLE
Fix homogenize not working with tuples

### DIFF
--- a/agate/table/homogenize.py
+++ b/agate/table/homogenize.py
@@ -64,7 +64,7 @@ def homogenize(self, key, compare_values, default_row=None):
             rows.append(Row(default_row(difference), self._column_names))
         else:
             if default_row is not None:
-                new_row = default_row
+                new_row = list(default_row)
             else:
                 new_row = [None] * (len(self._column_names) - len(key))
 


### PR DESCRIPTION
Also fixes data corruption bug due to lists being mutable.

With agate 1.6.0, default [homogenize example](http://agate.readthedocs.io/en/1.6.0/cookbook/homogenize.html):
```
>>> table.homogenize('year', range(1997, 2003), (0, 0))
AttributeError: 'tuple' object has no attribute 'insert'
>>> table.homogenize('year', range(1997, 2003), [0, 0])
(('year', Decimal('1997')), ('f', Decimal('2')), ('m', Decimal('1')))
(('year', Decimal('2000')), ('f', Decimal('4')), ('m', Decimal('3')))
(('year', Decimal('2002')), ('f', Decimal('4')), ('m', Decimal('5')))
(('year', Decimal('2003')), ('f', Decimal('1')), ('m', Decimal('2')))
(('year', 1999), ('f', 0), ('m', 0))
(('year', 1998), ('f', 1999), ('m', 0))
(('year', 2001), ('f', 1998), ('m', 1999))
```

With fix (for both tuples and list arguments):
```
(('year', Decimal('1997')), ('f', Decimal('2')), ('m', Decimal('1')))
(('year', Decimal('2000')), ('f', Decimal('4')), ('m', Decimal('3')))
(('year', Decimal('2002')), ('f', Decimal('4')), ('m', Decimal('5')))
(('year', Decimal('2003')), ('f', Decimal('1')), ('m', Decimal('2')))
(('year', 1999), ('f', 0), ('m', 0))
(('year', 1998), ('f', 0), ('m', 0))
(('year', 2001), ('f', 0), ('m', 0))
```

Edit: fixes (hopefully) #699 