### PR TITLE
Don't calculate precision of infinity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/agate/table/print_table.py
+++ b/agate/table/print_table.py
@@ -96,9 +96,7 @@ def print_table(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_
                 v = ellipsis
             elif v is None:
                 v = ''
-            elif math.isinf(v):
-                v = six.text_type(v)
-            elif number_formatters[j] is not None:
+            elif number_formatters[j] is not None and not math.isinf(v):
                 v = format_decimal(
                     v,
                     format=number_formatters[j],

--- a/agate/table/print_table.py
+++ b/agate/table/print_table.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # pylint: disable=W0212
 
+import math
 import sys
 
 from babel.numbers import format_decimal
@@ -95,6 +96,8 @@ def print_table(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_
                 v = ellipsis
             elif v is None:
                 v = ''
+            elif math.isinf(v):
+                v = six.text_type(v)
             elif number_formatters[j] is not None:
                 v = format_decimal(
                     v,

--- a/agate/utils.py
+++ b/agate/utils.py
@@ -133,7 +133,7 @@ def max_precision(values):
     precision = getcontext().prec
 
     for value in values:
-        if value is None or math.isnan(value):
+        if value is None or math.isnan(value) or math.isinf(value):
             continue
 
         sign, digits, exponent = value.normalize().as_tuple()

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,7 +45,7 @@ Supported platforms
 agate supports the following versions of Python:
 
 * Python 2.7
-* Python 3.3+
+* Python 3.4+
 * `PyPy <http://pypy.org/>`_ versions >= 4.0.0
 
 It is tested primarily on OSX, but due to its minimal dependencies it should work perfectly on both Linux and Windows.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
If `value` in `max_precision` is `Decimal('Infinity')`, then `exponent` gets set to `'F'`, causing an error. Similarly, if `v` in `print_table` is infinity, then `format_decimal` from Babel errors.