### PR TITLE
Allow the conversion of booleans to numbers

### DIFF
--- a/agate/data_types/number.py
+++ b/agate/data_types/number.py
@@ -70,6 +70,10 @@ class Number(DataType):
             return Decimal(d)
         elif t is float:
             return Decimal(repr(d))
+        elif t == False:
+            return Decimal(0)
+        elif t == True:
+            return Decimal(1)
         elif not isinstance(d, six.string_types):
             raise CastError('Can not parse value "%s" as Decimal.' % d)
 

--- a/agate/data_types/number.py
+++ b/agate/data_types/number.py
@@ -70,9 +70,9 @@ class Number(DataType):
             return Decimal(d)
         elif t is float:
             return Decimal(repr(d))
-        elif t == False:
+        elif d == False:
             return Decimal(0)
-        elif t == True:
+        elif d == True:
             return Decimal(1)
         elif not isinstance(d, six.string_types):
             raise CastError('Can not parse value "%s" as Decimal.' % d)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -124,7 +124,7 @@ class TestNumber(unittest.TestCase):
     def test_test(self):
         self.assertEqual(self.type.test(None), True)
         self.assertEqual(self.type.test('N/A'), True)
-        self.assertEqual(self.type.test(True), False)
+        self.assertEqual(self.type.test(True), True)
         self.assertEqual(self.type.test('True'), False)
         self.assertEqual(self.type.test(1), True)
         self.assertEqual(self.type.test(Decimal('1')), True)
@@ -155,6 +155,11 @@ class TestNumber(unittest.TestCase):
     def test_cast_long(self):
         self.assertEqual(self.type.test(long('141414')), True)
         self.assertEqual(self.type.cast(long('141414')), Decimal('141414'))
+
+    def test_boolean_cast(self):
+        values = (True, False)
+        casted = tuple(self.type.cast(v) for v in values)
+        self.assertSequenceEqual(casted, (Decimal('1'), Decimal('0')))
 
     def test_currency_cast(self):
         values = ('$2.70', '-$0.70', u'€14', u'50¢', u'-75¢', u'-$1,287')


### PR DESCRIPTION
When a table has a column with only `0` and `1` as values, the agate `TypeTester` detects a `Boolean` column. If later in a script we want to merge this table with another (let's say the same dataset for another year) where the very same column has other numbers (detected as a `Number` column), we need to convert the `Boolean` column to `Number`.

To do it properly in user code, we need to write a dictionary or a function, to take into account `0`/`False`, `1`/`True` and `None`. This is tiresome and subject to errors (when users might forget `None`; also when raising exceptions which won't be agate `CastError`s in this case).

This change would allow an easy change of column type: we would just need to change the data type of the column to cast the values correctly.

This is also coherent with Python 2 and 3 having `bool` as a subclass of `int` ([see e.g. here](https://stackoverflow.com/questions/2764017/is-false-0-and-true-1-an-implementation-detail-or-is-it-guaranteed-by-the)).