### PR TITLE
Sum should work with time deltas, also isinstance cleanups

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,4 @@ agate is made by a community. The following individuals have contributed code, d
 * `Kartik Agaram <https://github.com/akkartik>`_
 * `Loïc Corbasson <https://github.com/lcorbasson>`_
 * `Robert Schütz <https://github.com/dotlambda>`_
+* `Danny Sepler <https://github.com/dannysepler>`_

--- a/agate/aggregations/max.py
+++ b/agate/aggregations/max.py
@@ -21,18 +21,14 @@ class Max(Aggregation):
     def get_aggregate_data_type(self, table):
         column = table.columns[self._column_name]
 
-        if (isinstance(column.data_type, Number) or
-        isinstance(column.data_type, Date) or
-        isinstance(column.data_type, DateTime)):
+        if isinstance(column.data_type, (Number, Date, DateTime)):
             return column.data_type
 
     def validate(self, table):
         column = table.columns[self._column_name]
 
-        if not (isinstance(column.data_type, Number) or
-        isinstance(column.data_type, Date) or
-        isinstance(column.data_type, DateTime)):
-            raise DataTypeError('Min can only be applied to columns containing DateTime orNumber data.')
+        if not isinstance(column.data_type, (Number, Date, DateTime)):
+            raise DataTypeError('Min can only be applied to columns containing DateTime, Date or Number data.')
 
     def run(self, table):
         column = table.columns[self._column_name]

--- a/agate/aggregations/min.py
+++ b/agate/aggregations/min.py
@@ -21,18 +21,14 @@ class Min(Aggregation):
     def get_aggregate_data_type(self, table):
         column = table.columns[self._column_name]
 
-        if (isinstance(column.data_type, Number) or
-        isinstance(column.data_type, Date) or
-        isinstance(column.data_type, DateTime)):
+        if isinstance(column.data_type, (Number, Date, DateTime)):
             return column.data_type
 
     def validate(self, table):
         column = table.columns[self._column_name]
 
-        if not (isinstance(column.data_type, Number) or
-        isinstance(column.data_type, Date) or
-        isinstance(column.data_type, DateTime)):
-            raise DataTypeError('Min can only be applied to columns containing DateTime orNumber data.')
+        if not isinstance(column.data_type, (Number, Date, DateTime)):
+            raise DataTypeError('Min can only be applied to columns containing DateTime, Date or Number data.')
 
     def run(self, table):
         column = table.columns[self._column_name]

--- a/agate/aggregations/sum.py
+++ b/agate/aggregations/sum.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+import datetime
 
 from agate.aggregations.base import Aggregation
-from agate.data_types import Number
+from agate.data_types import Number, TimeDelta
 from agate.exceptions import DataTypeError
 
 
@@ -16,15 +17,22 @@ class Sum(Aggregation):
         self._column_name = column_name
 
     def get_aggregate_data_type(self, table):
-        return Number()
+        column = table.columns[self._column_name]
+
+        if isinstance(column.data_type, (Number, TimeDelta)):
+            return column.data_type
 
     def validate(self, table):
         column = table.columns[self._column_name]
 
-        if not isinstance(column.data_type, Number):
-            raise DataTypeError('Sum can only be applied to columns containing Number data.')
+        if not isinstance(column.data_type, (Number, TimeDelta)):
+            raise DataTypeError('Sum can only be applied to columns containing Number or TimeDelta data.')
 
     def run(self, table):
         column = table.columns[self._column_name]
 
-        return sum(column.values_without_nulls())
+        start = 0
+        if isinstance(column.data_type, TimeDelta):
+            start = datetime.timedelta()
+
+        return sum(column.values_without_nulls(), start)

--- a/agate/computations/change.py
+++ b/agate/computations/change.py
@@ -27,11 +27,7 @@ class Change(Computation):
     def get_computed_data_type(self, table):
         before_column = table.columns[self._before_column_name]
 
-        if isinstance(before_column.data_type, Date):
-            return TimeDelta()
-        elif isinstance(before_column.data_type, DateTime):
-            return TimeDelta()
-        elif isinstance(before_column.data_type, TimeDelta):
+        if isinstance(before_column.data_type, (Date, DateTime, TimeDelta)):
             return TimeDelta()
         elif isinstance(before_column.data_type, Number):
             return Number()

--- a/agate/table/pivot.py
+++ b/agate/table/pivot.py
@@ -110,7 +110,7 @@ def pivot(self, key=None, pivot=None, aggregation=None, computation=None, defaul
     if pivot is not None:
         groups = groups.group_by(pivot)
 
-        column_type = aggregation.get_aggregate_data_type(groups)
+        column_type = aggregation.get_aggregate_data_type(self)
 
         table = groups.aggregate([
             (aggregation_name, aggregation)

--- a/tests/test_aggregations.py
+++ b/tests/test_aggregations.py
@@ -207,6 +207,18 @@ class TestDateTimeAggregation(unittest.TestCase):
         Max('test').validate(table)
         self.assertEqual(Max('test').run(table), datetime.datetime(1994, 3, 3, 6, 31))
 
+    def test_sum(self):
+        rows = [
+            [datetime.timedelta(seconds=10)],
+            [datetime.timedelta(seconds=20)],
+        ]
+
+        table = Table(rows, ['test'], [TimeDelta()])
+
+        self.assertIsInstance(Sum('test').get_aggregate_data_type(table), TimeDelta)
+        Sum('test').validate(table)
+        self.assertEqual(Sum('test').run(table), datetime.timedelta(seconds=30))
+
 
 class TestNumberAggregation(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
hi! i found this a compelling issue to look at https://github.com/wireservice/csvkit/issues/1029

given i'm pretty new to open source (as well as agate), i was wondering your opinion on a few things:

1. besides running unit tests, what would you imagine would be a good testing plan here?
2. my additions broke the "pivot" unit tests in the following way (which i resolved in this PR):

```
___ TestPivot.test_pivot_sum ___
self = <tests.test_table.test_pivot.TestPivot testMethod=test_pivot_sum>
    def test_pivot_sum(self):
        table = Table(self.rows, self.column_names, self.column_types)
>       pivot_table = table.pivot('race', 'gender', Sum('age'))
tests/test_table/test_pivot.py:120:
_ _ _ 
agate/table/pivot.py:113: in pivot
    column_type = aggregation.get_aggregate_data_type(groups)
_ _ _
self = <agate.aggregations.sum.Sum object at 0x101717f90>, table = <agate.tableset.TableSet object at 0x10171db40>
    def get_aggregate_data_type(self, table):
>       column = table.columns[self._column_name]
E       AttributeError: 'TableSet' object has no attribute 'columns'
```

this seems to be because we get the data type from "groups" rather than the whole table. is this a good patch or not really?

3. would you prefer i break out the isinstance cleanups into another diff?

thanks all!