### PR TITLE
import Sequence from collections.abc to suppress warning in python 3.…

### DIFF
--- a/agate/mapped_sequence.py
+++ b/agate/mapped_sequence.py
@@ -6,7 +6,11 @@ for agate's :class:`.Row` and :class:`.Column` as well as for named sequences of
 rows and columns.
 """
 
-from collections import OrderedDict, Sequence
+from collections import OrderedDict
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 import six
 from six.moves import range  # pylint: disable=W0622

--- a/agate/utils.py
+++ b/agate/utils.py
@@ -6,7 +6,11 @@ This module contains a collection of utility classes and functions used in
 agate.
 """
 
-from collections import OrderedDict, Sequence
+from collections import OrderedDict
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from functools import wraps
 import math
 import string


### PR DESCRIPTION
`Sequence` should be imported from `collections.abc` instead of `collections` since Python 3.3. A warning is printed starting with Python 3.7 and in Python 3.9 the new import location will be required.

This PR imports from `collections.abc` while still falling back to importing from `collections` for older Python versions.