### PR TITLE
Idea: Use one-char ellipsis symbol in more places

### DIFF
--- a/agate/config.py
+++ b/agate/config.py
@@ -27,7 +27,7 @@ configuration.
 +-------------------------+------------------------------------------+-----------------------------------------+
 | tick_char               | Character to render for axis ticks       | u'+'                                    |
 +-------------------------+------------------------------------------+-----------------------------------------+
-| ellipsis_chars          | Characters to render for ellipsis        | u'...'                                  |
+| ellipsis_char           | Character to render for ellipsis         | u'…'                                    |
 +-------------------------+------------------------------------------+-----------------------------------------+
 
 """
@@ -52,8 +52,8 @@ _options = {
     'printable_zero_line_char': u'|',
     #: Character to render for axis ticks
     'tick_char': u'+',
-    #: Characters to render for ellipsis
-    'ellipsis_chars': u'...',
+    #: Character to render for ellipsis
+    'ellipsis_char': u'…',
 }
 
 

--- a/agate/table/print_html.py
+++ b/agate/table/print_html.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf8 -*-
 # pylint: disable=W0212
 
 import sys
@@ -39,7 +40,7 @@ def print_html(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_w
     if max_columns is None:
         max_columns = len(self._columns)
 
-    ellipsis = config.get_option('ellipsis_chars')
+    ellipsis = config.get_option('ellipsis_char')
     locale = locale or config.get_option('default_locale')
 
     rows_truncated = max_rows < len(self._rows)
@@ -86,7 +87,7 @@ def print_html(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_w
                 v = six.text_type(v)
 
             if max_column_width is not None and len(v) > max_column_width:
-                v = '%s...' % v[:max_column_width - 3]
+                v = u'%s…' % v[:max_column_width - 1]
 
             formatted_row.append(v)
 

--- a/agate/table/print_table.py
+++ b/agate/table/print_table.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf8 -*-
 # pylint: disable=W0212
 
 import math
@@ -48,7 +49,7 @@ def print_table(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_
     if max_precision is None:
         max_precision = float('inf')
 
-    ellipsis = config.get_option('ellipsis_chars')
+    ellipsis = config.get_option('ellipsis_char')
     h_line = config.get_option('horizontal_line_char')
     v_line = config.get_option('vertical_line_char')
     locale = locale or config.get_option('default_locale')
@@ -58,7 +59,7 @@ def print_table(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_
     column_names = []
     for column_name in self.column_names[:max_columns]:
         if max_column_width is not None and len(column_name) > max_column_width:
-            column_names.append('%s...' % column_name[:max_column_width - 3])
+            column_names.append(u'%s…' % column_name[:max_column_width - 1])
         else:
             column_names.append(column_name)
 
@@ -106,7 +107,7 @@ def print_table(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_
                 v = six.text_type(v)
 
             if max_column_width is not None and len(v) > max_column_width:
-                v = '%s...' % v[:max_column_width - 3]
+                v = u'%s…' % v[:max_column_width - 1]
 
             if len(v) > widths[j]:
                 widths[j] = len(v)

--- a/tests/test_table/test_print_table.py
+++ b/tests/test_table/test_print_table.py
@@ -58,7 +58,7 @@ class TestPrintTable(AgateTestCase):
         lines = output.getvalue().split('\n')
 
         self.assertEqual(len(lines), 6)
-        self.assertEqual(len(lines[0]), 23)
+        self.assertEqual(len(lines[0]), 21)
 
     def test_print_table_max_precision(self):
         rows = (
@@ -106,8 +106,8 @@ class TestPrintTable(AgateTestCase):
         table.print_table(output=output, max_column_width=7)
         lines = output.getvalue().split('\n')
 
-        self.assertIn(' also... ', lines[0])
-        self.assertIn(' this... ', lines[2])
+        self.assertIn(u' also, … ', lines[0])
+        self.assertIn(u' this i… ', lines[2])
         self.assertIn(' nope ', lines[4])
 
     def test_print_table_locale_american(self):


### PR DESCRIPTION
In print_table() and print_html(), when the column width exceeds the `max_column_width`, the ellipsis symbol factors into that `max_column` size. The three letters of a normal ellipsis are kinda bulky, especially when we have small max sizes like here: https://github.com/wireservice/csvkit/issues/941

There's a few things we can do!

1. As the author suggests, make the ellipsis char a parameter. _Might not be necessary to expose to the user. They'd probably just toggle it off?_


2. As the reviewer suggests, make the `max_precision` customizable. _This might not fix the issue, since `print_table` will still chop off the more precise value to insert the ellipsis characters_


3. Give "use_ellipsis", or "truncate_decimals" as a passed-in parameter. When it's false, we don't use the ellipsis in decimals. (I'm guessing non-decimals would need the ellipsis all the time?). _This requires a bit more work with decimal parsing, but is totally possible_


4. (This diff) Use the one-char ellipsis in `print_table` and `print_html`. _This is the simplest way to fix the readability in the issue above, so I chose it. It's also already used in "utils" so hooray for consistency?_