### PR TITLE
Fix deprecated import of ABC from collections

### DIFF
--- a/agate/utils.py
+++ b/agate/utils.py
@@ -8,10 +8,7 @@ agate.
 
 from collections import OrderedDict
 
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
+from collections.abc import Sequence
 
 import math
 import string


### PR DESCRIPTION
According to the homepage, this project supports Python 3.6 and above.

Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it stopped working.

I noticed this because I ran with `export PYTHONDEVMODE=1` and then python screams at you. 😳