### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     author='Christopher Groskopf',
     author_email='chrisgroskopf@gmail.com',
     url='http://agate.readthedocs.org/',
+    project_urls={
+        'Source': 'https://github.com/wireservice/agate',
+    },
     license='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)