### PR TITLE
Replace newline characters in print_table()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -48,3 +48,4 @@ agate is made by a community. The following individuals have contributed code, d
 * `castorf <https://github.com/castorf>`_
 * `Julien Enselme <https://github.com/Jenselme>`__
 * `Scott Gigante <https://github.com/scottgigante>`__
+* `John Paul Martyn <https://github.com/catowhee>`__

--- a/agate/table/print_table.py
+++ b/agate/table/print_table.py
@@ -101,7 +101,7 @@ def print_table(self, max_rows=20, max_columns=6, output=sys.stdout, max_column_
                     locale=locale
                 )
             else:
-                v = str(v)
+                v = str(v).replace('\n', '↵')
 
             if max_column_width is not None and len(v) > max_column_width:
                 v = '%s%s' % (v[:max_column_width - len_truncation], truncation)

--- a/tests/test_table/test_print_table.py
+++ b/tests/test_table/test_print_table.py
@@ -133,9 +133,7 @@ class TestPrintTable(AgateTestCase):
         self.assertTrue("2.000" in output.getvalue())
 
     def test_print_table_replace_newlines(self):
-        """
-        Verify that \n characters are replaced with the '↵' symbol. 
-        """
+        """Verify that \n characters are replaced with the '↵' symbol."""
         rows = (
             ('1.7', 2000, 2000, 'a\nvalue with one newline'),
             ('11.18', None, None, None),

--- a/tests/test_table/test_print_table.py
+++ b/tests/test_table/test_print_table.py
@@ -131,3 +131,22 @@ class TestPrintTable(AgateTestCase):
         table.print_table(max_columns=2, output=output, locale='de_DE.UTF-8')
         # If it's working, the english '2,000' should appear as '2.000'
         self.assertTrue("2.000" in output.getvalue())
+
+    def test_print_table_replace_newlines(self):
+        """
+        Verify that \n characters are replaced with the '↵' symbol. 
+        """
+        rows = (
+            ('1.7', 2000, 2000, 'a\nvalue with one newline'),
+            ('11.18', None, None, None),
+            ('0', 1, 1, 'a\n\nvalue with two newlines')
+        )
+
+        table = Table(rows, self.column_names, self.column_types)
+
+        output = StringIO()
+        table.print_table(output=output, max_column_width=30)
+        lines = output.getvalue().split('\n')
+
+        self.assertIn('a↵value with one newline', lines[2])
+        self.assertIn('a↵↵value with two newlines', lines[4])


### PR DESCRIPTION
closes #749 

Replaces `\n` with `↵` to keep the output of `print_table` readable. Added a test to `test_print_table.py`.