### PR TITLE
Fix tuple syntax when using key sequence in distinct()

### DIFF
--- a/agate/table/distinct.py
+++ b/agate/table/distinct.py
@@ -28,7 +28,7 @@ def distinct(self, key=None):
         if key_is_row_function:
             k = key(row)
         elif key_is_sequence:
-            k = (row[j] for j in key)
+            k = tuple(row[j] for j in key)
         elif key is None:
             k = tuple(row)
         else:


### PR DESCRIPTION
I have noticed in the past that `Table.distinct()` does not deduplicate when the key is a list or sequence of column names.

Code like this (wrongly) results in no rows being dropped ...

```table = table.distinct(['PARCELID', 'SITEADDR'])```

... whereas code like this _does_ successfully drop duplicate rows:

```table = table.distinct(lambda row: str(row['PARCELID']) + str(row['SITEADDR']))```

I believe the cause is line 31 of `agate/table/distinct.py`, which constructs the row's key for de-duplicating:

```k = (row[j] for j in key)```

I think the parentheses here create are creating a generator expression, not a tuple. `k` is always unique, and no de-duplication ever occurs.

My suggested fix is to wrap it with `tuple(...)`:

```k = tuple(row[j] for j in key)```

