### PR TITLE
Fix Rank placing null values first when reverse=True

### DIFF
--- a/agate/computations/rank.py
+++ b/agate/computations/rank.py
@@ -39,11 +39,14 @@ class Rank(Computation):
 
         if self._comparer:
             data_sorted = sorted(column.values(), key=cmp_to_key(self._comparer))
+            if self._reverse:
+                data_sorted.reverse()
         else:
-            data_sorted = column.values_sorted()
-
-        if self._reverse:
-            data_sorted.reverse()
+            non_nulls = sorted(v for v in column.values() if v is not None)
+            if self._reverse:
+                non_nulls.reverse()
+            null_count = sum(1 for v in column.values() if v is None)
+            data_sorted = non_nulls + [None] * null_count
 
         ranks = {}
         rank = 0

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -305,6 +305,15 @@ class TestTableComputation(unittest.TestCase):
         self.assertEqual(len(new_table.columns), 5)
         self.assertSequenceEqual(new_table.columns['rank'], (3, 1, 3, 1))
 
+    def test_rank_number_reverse_nulls_ranked_last(self):
+        """Null values must remain ranked last even when reverse=True."""
+        rows = [(1,), (2,), (None,), (3,)]
+        table = Table(rows, ['n'], [self.number_type])
+        new_table = table.compute([('rank', Rank('n', reverse=True))])
+
+        # 3 is highest -> rank 1; 2 -> rank 2; 1 -> rank 3; None -> rank 4 (last)
+        self.assertSequenceEqual(new_table.columns['rank'], (3, 2, 4, 1))
+
     def test_rank_number_key(self):
         new_table = self.table.compute([
             ('rank', Rank('two', comparer=lambda x, y: int(y - x)))


### PR DESCRIPTION
## Summary

`Rank` documents that *"Null values will always be ranked last."*  That guarantee breaks when `reverse=True` is used without a custom `comparer`.

### Root cause

`values_sorted()` uses `NullOrder` to sort nulls to the end of the list.  Then `data_sorted.reverse()` flips the whole list, moving those nulls to the front — so they receive rank 1 instead of the last rank.

### Reproducer

```python
import agate

table = agate.Table(
    [[1], [2], [None], [3]],
    ['value'],
    [agate.Number()]
)
result = table.compute([('rank', agate.Rank('value', reverse=True))])
for row in result.rows:
    print(row['value'], row['rank'])
# Before fix:
#   1  -> 4
#   2  -> 3
#   None -> 1   ← should be 4 (last)
#   3  -> 2
```

### Fix

When `reverse=True` and no custom comparer is given, sort only the non-null values, reverse those, then append the nulls at the end.  The comparer path is unchanged (null handling there is the user's responsibility).

A regression test `test_rank_number_reverse_nulls_ranked_last` is added.

---

This pull request was prepared with the assistance of AI, under my direction and review.