### PR TITLE
fix: Table.distinct deduplicates when key is a sequence of column names

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,3 +51,4 @@ agate is made by a community. The following individuals have contributed code, d
 * `John Paul Martyn <https://github.com/catowhee>`__
 * `Michał Górny <https://github.com/mgorny>`__
 * `Karthik Ramadugu <https://github.com/karthiksai109>`__
+* `Josh Renaud <https://github.com/Kirkman>`__

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.14.3 - Unreleased
+-------------------
+
+- fix: :meth:`.Table.distinct` now deduplicates rows when ``key`` is a sequence of column names.
+
 1.14.2 - February 27, 2026
 --------------------------
 

--- a/agate/table/distinct.py
+++ b/agate/table/distinct.py
@@ -28,7 +28,7 @@ def distinct(self, key=None):
         if key_is_row_function:
             k = key(row)
         elif key_is_sequence:
-            k = (row[j] for j in key)
+            k = tuple(row[j] for j in key)
         elif key is None:
             k = tuple(row)
         else:

--- a/tests/test_table/__init__.py
+++ b/tests/test_table/__init__.py
@@ -535,6 +535,7 @@ class TestBasic(AgateTestCase):
         self.assertIsNot(new_table, table)
         self.assertColumnNames(new_table, self.column_names)
         self.assertColumnTypes(new_table, [Number, Number, Text])
+        self.assertEqual(len(new_table.rows), 3)
         self.assertRows(new_table, [
             rows[0],
             rows[1],


### PR DESCRIPTION
The key was built as a generator expression `(row[j] for j in key)`
instead of a tuple, so every key was a unique object and no rows were
ever deduplicated. Wrap it in tuple() to compare by value.

Add a row-count assertion to test_distinct_multiple_columns (the
existing assertRows only checks the leading expected rows, so the
extra un-deduplicated row went undetected), add a CHANGELOG entry,
and credit Josh Renaud in AUTHORS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B97HBLFpceJe7ajprfv1HJ