### PR TITLE
Fix Rank placing null values first when reverse=True

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,3 +52,4 @@ agate is made by a community. The following individuals have contributed code, d
 * `Michał Górny <https://github.com/mgorny>`__
 * `Karthik Ramadugu <https://github.com/karthiksai109>`__
 * `Josh Renaud <https://github.com/Kirkman>`__
+* `Vincent Gao <https://github.com/gaoflow>`__

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 -------------------
 
 - fix: :meth:`.Table.distinct` now deduplicates rows when ``key`` is a sequence of column names.
+- fix: :class:`.Rank` ranks null values last when ``reverse=True``.
 
 1.14.2 - February 27, 2026
 --------------------------

--- a/agate/computations/rank.py
+++ b/agate/computations/rank.py
@@ -39,11 +39,14 @@ class Rank(Computation):
 
         if self._comparer:
             data_sorted = sorted(column.values(), key=cmp_to_key(self._comparer))
+            if self._reverse:
+                data_sorted.reverse()
         else:
-            data_sorted = column.values_sorted()
-
-        if self._reverse:
-            data_sorted.reverse()
+            non_nulls = sorted(v for v in column.values() if v is not None)
+            if self._reverse:
+                non_nulls.reverse()
+            null_count = sum(1 for v in column.values() if v is None)
+            data_sorted = non_nulls + [None] * null_count
 
         ranks = {}
         rank = 0

--- a/agate/computations/rank.py
+++ b/agate/computations/rank.py
@@ -42,11 +42,10 @@ class Rank(Computation):
             if self._reverse:
                 data_sorted.reverse()
         else:
-            non_nulls = sorted(v for v in column.values() if v is not None)
+            non_nulls = list(column.values_without_nulls_sorted())
             if self._reverse:
                 non_nulls.reverse()
-            null_count = sum(1 for v in column.values() if v is None)
-            data_sorted = non_nulls + [None] * null_count
+            data_sorted = non_nulls + [None] * (len(column.values()) - len(non_nulls))
 
         ranks = {}
         rank = 0

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -305,6 +305,15 @@ class TestTableComputation(unittest.TestCase):
         self.assertEqual(len(new_table.columns), 5)
         self.assertSequenceEqual(new_table.columns['rank'], (3, 1, 3, 1))
 
+    def test_rank_number_reverse_nulls_ranked_last(self):
+        """Null values must remain ranked last even when reverse=True."""
+        rows = [(1,), (2,), (None,), (3,)]
+        table = Table(rows, ['n'], [self.number_type])
+        new_table = table.compute([('rank', Rank('n', reverse=True))])
+
+        # 3 is highest -> rank 1; 2 -> rank 2; 1 -> rank 3; None -> rank 4 (last)
+        self.assertSequenceEqual(new_table.columns['rank'], (3, 2, 4, 1))
+
     def test_rank_number_key(self):
         new_table = self.table.compute([
             ('rank', Rank('two', comparer=lambda x, y: int(y - x)))


### PR DESCRIPTION
Rank documents that null values are always ranked last, but that broke
with reverse=True and no custom comparer: values_sorted() sorted nulls
to the end via NullOrder, then data_sorted.reverse() flipped the whole
list, moving nulls to the front (rank 1).

Sort only the non-null values, reverse those when requested, then append
the nulls at the end. The custom-comparer path is unchanged.

Adds a regression test, credits the author in AUTHORS.rst, and notes the
fix in the changelog.

Co-authored-by: Vincent Gao <gaobing1230@gmail.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETgvBkDGRPZZQgJQWnfyfM